### PR TITLE
fix cookie token error

### DIFF
--- a/src/cookie_lexer.rs
+++ b/src/cookie_lexer.rs
@@ -35,7 +35,7 @@ impl std::error::Error for CookieLexerError {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum CookieToken {
     CookieOctets,
     TokenOrCookieOctets,
@@ -112,7 +112,8 @@ macro_rules! try_nonrepeating_char_match {
             && ($data.len() == $cursor + 1 || {
                 let (_, next_char) = $data[$cursor + 1];
                 next_char != $chr
-            }) {
+            })
+        {
             let token_idx = $cursor;
             let token_end = token_idx + char_val.len_utf8();
             $cursor = token_end;


### PR DESCRIPTION
We've started experiencing an error in CI with this crate. For example [this PR failed](https://github.com/rust-net-web/tide/pull/124#event-2087748554) ([CI](https://travis-ci.org/rust-net-web/tide/builds/482347454?utm_source=github_status&utm_medium=notification)).

I suspect one of this crate's dependencies updated their trait bound requirements which now means this fails to compile. This patch fixes that issue.

Thanks heaps!